### PR TITLE
ensure 1:1.9 aspect ratio with margin

### DIFF
--- a/lib/images.py
+++ b/lib/images.py
@@ -30,13 +30,34 @@ def getLogo(title: str, chrome=CHROME_PATH):
 
 
 def _trimWhitespace(im):
+    # calculate bbox of image area
     bg = Image.new(im.mode, im.size, im.getpixel((0, 0)))
     diff = ImageChops.difference(im, bg)
     diff = ImageChops.add(diff, diff, 2.0, -100)
     bbox = diff.getbbox()
-    if bbox:
-        return im.crop(bbox)
 
+    if bbox:
+        # crop the image and store sizes as variables
+        croppedImage = im.crop(bbox)
+        croppedImageWidth = croppedImage.size[0]
+        croppedImageHeight = croppedImage.size[1]
+
+        # calculate size of output image based on width of cropped image,
+        # 1:1.9 aspect ratio, and side margin pixels
+        SIDE_MARGIN = 30
+        outputImageWidth = croppedImageWidth + (SIDE_MARGIN * 2)
+        outputImageHeight = int(outputImageWidth * 0.52632)
+        outputImageSize = tuple([outputImageWidth, outputImageHeight])
+
+        # create empty image
+        outputImage = Image.new(im.mode, outputImageSize, im.getpixel((0, 0)))
+
+        # calculate positioning of cropped image on empty background, paste
+        x = SIDE_MARGIN
+        y = int((outputImageHeight - croppedImageHeight) / 2)
+        outputImage.paste(croppedImage, (x, y))
+
+        return outputImage
 
 def _cropOffTopAndBottom(image_path: str):
     im = Image.open(image_path)


### PR DESCRIPTION
Twitter prefers a 1:1.9 aspect ratio for attached images.  The current code crops the generated logo, whose width and height can vary depending on the wiki title. This leads to inconsistent/suboptimal display in twitter feeds, which will zoom in on the image to fill the content area.

This PR modifies `_trimWhitespace()` in `lib/images.py` to do additional processing, creating a 1:1.9 aspect ratio output image based on the cropped TMNT-style logo.  It also adds 30 pixels of horizontal margin, yielding final images that look like this:

![logo](https://user-images.githubusercontent.com/1833820/59896192-91715c80-93b5-11e9-8d70-91c14593ebd5.png)
