### PR TITLE
fix broken logos

### DIFF
--- a/lib/words.py
+++ b/lib/words.py
@@ -22,6 +22,10 @@ def isTMNT(title: str):
         "10101010",
     )
 
+    if title.count(' ') < 3:
+        # phrase needs 4 separate words to generate a logo
+        return False 
+
     for phrase in BANNED:
         if phrase in title.lower():
             return False


### PR DESCRIPTION
A phrase with fewer than four words breaks the logo generator, as seen here:

https://twitter.com/wiki_tmnt/status/1140239196008800258 :
![](https://pbs.twimg.com/media/D9LxgalVAAASUVq.png)

A quick count of spaces should help reduce these.