### PR TITLE
Update containsBanned from "and" to "or"

### DIFF
--- a/lib/words.py
+++ b/lib/words.py
@@ -56,7 +56,7 @@ def containsBanned(title: str):
                 return True
         return False
 
-    return _containsBannedWord(title) and _containsBannedPhrase(title)
+    return _containsBannedWord(title) or _containsBannedPhrase(title)
 
 
 def getTitleStresses(title: str):


### PR DESCRIPTION
`containsBanned` should return True if either of its helper functions returns True, not just if both do. This means it's currently letting through titles with "Historic District" that don't *also* have a banned word. To fix this, I just changed "and" to "or" in the return statement.