### PR TITLE
Remove placeholder test, no longer needed

### DIFF
--- a/tests/test_words.py
+++ b/tests/test_words.py
@@ -81,11 +81,6 @@ class GetWordStressesTest(unittest.TestCase):
         test_word = "Turtles"
         self.assertEqual(words.getWordStresses(test_word), "10")
 
-    def test_get_word_stresses_index_error(self):
-        """
-        """
-        pass
-
     def test_get_word_stresses_pronunciation_override(self):
         """
         For a word on the Pronunciation Override list, return the


### PR DESCRIPTION
In https://github.com/catleeball/tmnt_wikipedia_bot/pull/15 I added a placeholder test for some code I had a question about. Since that code [got removed](https://github.com/catleeball/tmnt_wikipedia_bot/commit/e0d8b65d194ce62ccef7537c085d19379ccf7831), this is just a small cleanup PR to remove that test shell.